### PR TITLE
Prefer to not destructure AssignmentExpressions

### DIFF
--- a/kintent-rules.js
+++ b/kintent-rules.js
@@ -1,80 +1,67 @@
-const confusingBrowserGlobals = require('confusing-browser-globals');
+const confusingBrowserGlobals = require("confusing-browser-globals");
 
 module.exports = {
-  "env": {
-    "node": true,
-    "es2020": true,
-    "mocha": true
+  env: {
+    node: true,
+    es2020: true,
+    mocha: true,
   },
-  "globals": {
-    "assert": false,
-    "expect": false,
-    "should": false
+  globals: {
+    assert: false,
+    expect: false,
+    should: false,
   },
-  "parserOptions": {
-    "ecmaFeatures": {
-      "generators": false,
-      "objectLiteralDuplicateProperties": false
+  parserOptions: {
+    ecmaFeatures: {
+      generators: false,
+      objectLiteralDuplicateProperties: false,
     },
-    "ecmaVersion": 2020,
-    "sourceType": "module"
+    ecmaVersion: 2020,
+    sourceType: "module",
   },
-  "plugins": [
-    'import'
-  ],
+  plugins: ["import"],
 
-  "settings": {
-    'import/resolver': {
+  settings: {
+    "import/resolver": {
       node: {
-        extensions: ['.mjs', '.js', '.json']
-      }
+        extensions: [".mjs", ".js", ".json"],
+      },
     },
-    'import/extensions': [
-      '.js',
-      '.mjs',
-      '.jsx',
-    ],
-    'import/core-modules': [
-    ],
-    'import/ignore': [
-      'node_modules',
-      '\\.(coffee|scss|css|less|hbs|svg|json)$',
+    "import/extensions": [".js", ".mjs", ".jsx"],
+    "import/core-modules": [],
+    "import/ignore": [
+      "node_modules",
+      "\\.(coffee|scss|css|less|hbs|svg|json)$",
     ],
   },
-  "rules": {
+  rules: {
     "accessor-pairs": "off",
     "array-callback-return": ["error", { allowImplicit: true }],
     "block-scoped-var": "error",
-    "complexity": [
-      "warn",
-      11
-    ],
-    "class-methods-use-this": ['error', {
-      exceptMethods: [],
-    }],
-    "consistent-return": "error",
-    "curly": [
+    complexity: ["warn", 11],
+    "class-methods-use-this": [
       "error",
-      "multi-line"
+      {
+        exceptMethods: [],
+      },
     ],
+    "consistent-return": "error",
+    curly: ["error", "multi-line"],
     "default-case": [
       "error",
       {
-        "commentPattern": "^no default$"
-      }
+        commentPattern: "^no default$",
+      },
     ],
     "default-param-last": "off",
     "dot-notation": [
       "error",
       {
-        "allowKeywords": true
-      }
+        allowKeywords: true,
+      },
     ],
-    "dot-location": [
-      "error",
-      "property"
-    ],
-    "eqeqeq": ["error", "always", { null: "ignore" }],
+    "dot-location": ["error", "property"],
+    eqeqeq: ["error", "always", { null: "ignore" }],
     "grouped-accessor-pairs": "error",
     "guard-for-in": "error",
     "max-classes-per-file": ["error", 1],
@@ -87,12 +74,8 @@ module.exports = {
     "no-empty-function": [
       "error",
       {
-        "allow": [
-          "arrowFunctions",
-          "functions",
-          "methods"
-        ]
-      }
+        allow: ["arrowFunctions", "functions", "methods"],
+      },
     ],
     "no-empty-pattern": "error",
     "no-eq-null": "off",
@@ -105,18 +88,18 @@ module.exports = {
     "no-global-assign": [
       "error",
       {
-        "exceptions": []
-      }
+        exceptions: [],
+      },
     ],
     "no-native-reassign": "off",
     "no-implicit-coercion": [
       "off",
       {
-        "boolean": false,
-        "number": true,
-        "string": true,
-        "allow": []
-      }
+        boolean: false,
+        number: true,
+        string: true,
+        allow: [],
+      },
     ],
     "no-implicit-globals": "off",
     "no-implied-eval": "error",
@@ -125,24 +108,27 @@ module.exports = {
     "no-labels": [
       "error",
       {
-        "allowLoop": false,
-        "allowSwitch": false
-      }
+        allowLoop: false,
+        allowSwitch: false,
+      },
     ],
     "no-lone-blocks": "error",
     "no-loop-func": "error",
     "no-magic-numbers": [
       "off",
       {
-        "ignore": [],
-        "ignoreArrayIndexes": true,
-        "enforceConst": true,
-        "detectObjects": false
-      }
+        ignore: [],
+        ignoreArrayIndexes: true,
+        enforceConst: true,
+        detectObjects: false,
+      },
     ],
-    "no-multi-spaces": ["error", {
-      ignoreEOLComments: false,
-    }],
+    "no-multi-spaces": [
+      "error",
+      {
+        ignoreEOLComments: false,
+      },
+    ],
     "no-multi-str": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -152,51 +138,66 @@ module.exports = {
     "no-param-reassign": "error",
     "no-proto": "error",
     "no-redeclare": "error",
-    "no-restricted-properties": ["error", {
-      object: "arguments",
-      property: "callee",
-      message: "arguments.callee is deprecated",
-    }, {
-      object: "global",
-      property: "isFinite",
-      message: "Please use Number.isFinite instead",
-    }, {
-      object: "self",
-      property: "isFinite",
-      message: "Please use Number.isFinite instead",
-    }, {
-      object: "window",
-      property: "isFinite",
-      message: "Please use Number.isFinite instead",
-    }, {
-      object: "global",
-      property: "isNaN",
-      message: "Please use Number.isNaN instead",
-    }, {
-      object: "self",
-      property: "isNaN",
-      message: "Please use Number.isNaN instead",
-    }, {
-      object: "window",
-      property: "isNaN",
-      message: "Please use Number.isNaN instead",
-    }, {
-      property: "__defineGetter__",
-      message: "Please use Object.defineProperty instead.",
-    }, {
-      property: "__defineSetter__",
-      message: "Please use Object.defineProperty instead.",
-    }, {
-      object: "Math",
-      property: "pow",
-      message: "Use the exponentiation operator (**) instead.",
-    }],
+    "no-restricted-properties": [
+      "error",
+      {
+        object: "arguments",
+        property: "callee",
+        message: "arguments.callee is deprecated",
+      },
+      {
+        object: "global",
+        property: "isFinite",
+        message: "Please use Number.isFinite instead",
+      },
+      {
+        object: "self",
+        property: "isFinite",
+        message: "Please use Number.isFinite instead",
+      },
+      {
+        object: "window",
+        property: "isFinite",
+        message: "Please use Number.isFinite instead",
+      },
+      {
+        object: "global",
+        property: "isNaN",
+        message: "Please use Number.isNaN instead",
+      },
+      {
+        object: "self",
+        property: "isNaN",
+        message: "Please use Number.isNaN instead",
+      },
+      {
+        object: "window",
+        property: "isNaN",
+        message: "Please use Number.isNaN instead",
+      },
+      {
+        property: "__defineGetter__",
+        message: "Please use Object.defineProperty instead.",
+      },
+      {
+        property: "__defineSetter__",
+        message: "Please use Object.defineProperty instead.",
+      },
+      {
+        object: "Math",
+        property: "pow",
+        message: "Use the exponentiation operator (**) instead.",
+      },
+    ],
     "no-return-assign": ["error", "always"],
     "no-script-url": "error",
     "no-return-await": "error",
-    "no-self-assign": ["error", {
-      props: true,
-    }],
+    "no-self-assign": [
+      "error",
+      {
+        props: true,
+      },
+    ],
     "no-self-compare": "error",
     "no-sequences": "error",
     "no-throw-literal": "error",
@@ -204,10 +205,10 @@ module.exports = {
     "no-unused-expressions": [
       "error",
       {
-        "allowShortCircuit": false,
-        "allowTernary": false,
-        "allowTaggedTemplates": false
-      }
+        allowShortCircuit: false,
+        allowTernary: false,
+        allowTaggedTemplates: false,
+      },
     ],
     "no-unused-labels": "error",
     "no-useless-call": "off",
@@ -219,39 +220,32 @@ module.exports = {
     "no-warning-comments": [
       "off",
       {
-        "terms": [
-          "todo",
-          "fixme",
-          "xxx"
-        ],
-        "location": "start"
-      }
+        terms: ["todo", "fixme", "xxx"],
+        location: "start",
+      },
     ],
     "no-with": "error",
     "prefer-promise-reject-errors": ["error", { allowEmptyReject: true }],
     "prefer-named-capture-group": "off",
     "prefer-regex-literals": "error",
-    "radix": "error",
-    "require-await": "off",       // note: this is a horrible rule that should never be use
+    radix: "error",
+    "require-await": "off", // note: this is a horrible rule that should never be use
     "require-unicode-regexp": "off",
     "vars-on-top": "error",
     "wrap-iife": [
       "error",
       "outside",
       {
-        "functionPrototypeMethods": false
-      }
+        functionPrototypeMethods: false,
+      },
     ],
-    "yoda": "error",
+    yoda: "error",
     "for-direction": "error",
     "getter-return": ["error", { allowImplicit: true }],
     "no-async-promise-executor": "error",
     "no-await-in-loop": "error",
     "no-compare-neg-zero": "error",
-    "no-cond-assign": [
-      "error",
-      "always"
-    ],
+    "no-cond-assign": ["error", "always"],
     "no-console": "warn",
     "no-constant-condition": "warn",
     "no-control-regex": "error",
@@ -268,12 +262,12 @@ module.exports = {
       "off",
       "all",
       {
-        "conditionalAssign": true,
-        "nestedBinaryExpressions": false,
-        "returnAssign": false,
-        "ignoreJSX": "all",
-        "enforceForArrowConditionals": false
-      }
+        conditionalAssign: true,
+        nestedBinaryExpressions: false,
+        returnAssign: false,
+        ignoreJSX: "all",
+        enforceForArrowConditionals: false,
+      },
     ],
     "no-extra-semi": "error",
     "no-func-assign": "error",
@@ -299,17 +293,14 @@ module.exports = {
     "valid-typeof": [
       "error",
       {
-        "requireStringLiterals": true
-      }
+        requireStringLiterals: true,
+      },
     ],
     "callback-return": "off",
     "global-require": "warn",
     "handle-callback-err": "off",
     "no-buffer-constructor": "error",
-    "no-mixed-requires": [
-      "off",
-      false
-    ],
+    "no-mixed-requires": ["off", false],
     "no-new-require": "error",
     "no-path-concat": "error",
     "no-process-env": "off",
@@ -318,57 +309,59 @@ module.exports = {
     "no-sync": "off",
     "array-bracket-newline": ["off", "consistent"],
     "array-element-newline": ["off", { multiline: true, minItems: 3 }],
-    "array-bracket-spacing": [
-      "error",
-      "never"
-    ],
-    "block-spacing": [
-      "error",
-      "always"
-    ],
+    "array-bracket-spacing": ["error", "never"],
+    "block-spacing": ["error", "always"],
     "brace-style": [
       "error",
       "1tbs",
       {
-        "allowSingleLine": true
-      }
+        allowSingleLine: true,
+      },
     ],
-    "camelcase": [
+    camelcase: [
       "error",
       {
-        "properties": "never",
-        "ignoreDestructuring": false
-      }
+        properties: "never",
+        ignoreDestructuring: false,
+      },
     ],
-    "capitalized-comments": ["off", "never", {
-      line: {
-        ignorePattern: ".*",
-        ignoreInlineComments: true,
-        ignoreConsecutiveComments: true,
+    "capitalized-comments": [
+      "off",
+      "never",
+      {
+        line: {
+          ignorePattern: ".*",
+          ignoreInlineComments: true,
+          ignoreConsecutiveComments: true,
+        },
+        block: {
+          ignorePattern: ".*",
+          ignoreInlineComments: true,
+          ignoreConsecutiveComments: true,
+        },
       },
-      block: {
-        ignorePattern: '.*',
-        ignoreInlineComments: true,
-        ignoreConsecutiveComments: true,
+    ],
+    "comma-dangle": [
+      "off",
+      {
+        arrays: "always-multiline",
+        objects: "always-multiline",
+        imports: "always-multiline",
+        exports: "always-multiline",
+        functions: "always-multiline",
       },
-    }],
-    "comma-dangle": ["off", {
-      arrays: "always-multiline",
-      objects: "always-multiline",
-      imports: "always-multiline",
-      exports: "always-multiline",
-      functions: "always-multiline",
-    }],
+    ],
     "comma-spacing": [
       "error",
       {
-        "before": false,
-        "after": true
-      }
+        before: false,
+        after: true,
+      },
     ],
     "comma-style": [
       "error",
-      "last", {
+      "last",
+      {
         exceptions: {
           ArrayExpression: false,
           ArrayPattern: false,
@@ -381,176 +374,176 @@ module.exports = {
           ObjectPattern: false,
           VariableDeclaration: false,
           NewExpression: false,
-        }
-      }
+        },
+      },
     ],
-    "computed-property-spacing": [
-      "error",
-      "never"
-    ],
+    "computed-property-spacing": ["error", "never"],
     "consistent-this": "off",
-    "eol-last": [
-      "error",
-      "always"
-    ],
+    "eol-last": ["error", "always"],
     "function-call-argument-newline": ["off", "consistent"],
-    "func-call-spacing": [
-      "error",
-      "never"
-    ],
+    "func-call-spacing": ["error", "never"],
     "func-name-matching": [
       "off",
       "always",
       {
         includeCommonJSModuleExports: false,
         considerPropertyDescriptor: true,
-      }
+      },
     ],
     "func-names": "warn",
     "func-style": [
       "error",
-      "declaration", {
-        allowArrowFunctions: true
-      }
+      "declaration",
+      {
+        allowArrowFunctions: true,
+      },
     ],
     "function-paren-newline": ["error", "consistent"],
     "id-blacklist": "off",
     "id-length": "off",
     "id-match": "off",
     "implicit-arrow-linebreak": ["error", "beside"],
-    "indent": [
+    indent: [
       "error",
       2,
       {
-        "SwitchCase": 1,
-        "VariableDeclarator": 1,
-        "outerIIFEBody": 1,
-        "FunctionDeclaration": {
-          "parameters": 1,
-          "body": 1
+        SwitchCase: 1,
+        VariableDeclarator: 1,
+        outerIIFEBody: 1,
+        FunctionDeclaration: {
+          parameters: 1,
+          body: 1,
         },
-        "FunctionExpression": {
-          "parameters": 1,
-          "body": 1
+        FunctionExpression: {
+          parameters: 1,
+          body: 1,
         },
         CallExpression: {
-          arguments: 1
+          arguments: 1,
         },
         ArrayExpression: 1,
         ObjectExpression: 1,
         ImportDeclaration: 1,
         flatTernaryExpressions: false,
-        ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
-        ignoreComments: false
-      }
+        ignoredNodes: [
+          "JSXElement",
+          "JSXElement > *",
+          "JSXAttribute",
+          "JSXIdentifier",
+          "JSXNamespacedName",
+          "JSXMemberExpression",
+          "JSXSpreadAttribute",
+          "JSXExpressionContainer",
+          "JSXOpeningElement",
+          "JSXClosingElement",
+          "JSXText",
+          "JSXEmptyExpression",
+          "JSXSpreadChild",
+        ],
+        ignoreComments: false,
+      },
     ],
-    "jsx-quotes": [
-      "off",
-      "prefer-double"
-    ],
+    "jsx-quotes": ["off", "prefer-double"],
     "key-spacing": [
       "error",
       {
-        "beforeColon": false,
-        "afterColon": true
-      }
+        beforeColon: false,
+        afterColon: true,
+      },
     ],
     "keyword-spacing": [
       "error",
       {
-        "before": true,
-        "after": true,
-        "overrides": {
-          "return": {
-            "after": true
+        before: true,
+        after: true,
+        overrides: {
+          return: {
+            after: true,
           },
-          "throw": {
-            "after": true
+          throw: {
+            after: true,
           },
-          "case": {
-            "after": true
-          }
-        }
-      }
+          case: {
+            after: true,
+          },
+        },
+      },
     ],
     "line-comment-position": [
       "off",
       {
-        "position": "above",
-        "ignorePattern": "",
-        "applyDefaultPatterns": true
-      }
+        position: "above",
+        ignorePattern: "",
+        applyDefaultPatterns: true,
+      },
     ],
-    "linebreak-style": [
+    "linebreak-style": ["error", "unix"],
+    "lines-between-class-members": [
       "error",
-      "unix"
+      "always",
+      { exceptAfterSingleLine: false },
     ],
-    "lines-between-class-members": ["error", "always", { exceptAfterSingleLine: false }],
     "lines-around-comment": "off",
     "lines-around-directive": [
       "error",
       {
-        "before": "always",
-        "after": "always"
-      }
+        before: "always",
+        after: "always",
+      },
     ],
-    "max-depth": [
-      "off",
-      4
+    "max-depth": ["off", 4],
+    "max-len": [
+      "error",
+      120,
+      2,
+      {
+        ignoreUrls: true,
+        ignoreComments: false,
+        ignoreRegExpLiterals: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+      },
     ],
-    "max-len": ['error', 120, 2, {
-      ignoreUrls: true,
-      ignoreComments: false,
-      ignoreRegExpLiterals: true,
-      ignoreStrings: true,
-      ignoreTemplateLiterals: true,
-    }],
     "max-lines": [
       "off",
       {
-        "max": 300,
-        "skipBlankLines": true,
-        "skipComments": true
-      }
+        max: 300,
+        skipBlankLines: true,
+        skipComments: true,
+      },
     ],
-    "max-lines-per-function": ['warn', {
-      max: 50,
-      skipBlankLines: true,
-      skipComments: true,
-      IIFEs: true,
-    }],
+    "max-lines-per-function": [
+      "warn",
+      {
+        max: 50,
+        skipBlankLines: true,
+        skipComments: true,
+        IIFEs: true,
+      },
+    ],
     "max-nested-callbacks": "off",
-    "max-params": [
-      "off",
-      3
-    ],
-    "max-statements": [
-      "off",
-      10
-    ],
+    "max-params": ["off", 3],
+    "max-statements": ["off", 10],
     "max-statements-per-line": [
       "off",
       {
-        "max": 1
-      }
+        max: 1,
+      },
     ],
-    "multiline-comment-style": ['off', 'starred-block'],
-    "multiline-ternary": [
-      "off",
-      "never"
-    ],
+    "multiline-comment-style": ["off", "starred-block"],
+    "multiline-ternary": ["off", "never"],
     "new-cap": [
       "error",
       {
-        "newIsCap": true,
-        "newIsCapExceptions": [],
-        "capIsNew": false,
-        "capIsNewExceptions": [
+        newIsCap: true,
+        newIsCapExceptions: [],
+        capIsNew: false,
+        capIsNewExceptions: [
           "Immutable.Map",
           "Immutable.Set",
-          "Immutable.List"
-        ]
-      }
+          "Immutable.List",
+        ],
+      },
     ],
     "new-parens": "error",
     "newline-after-var": "off",
@@ -558,8 +551,8 @@ module.exports = {
     "newline-per-chained-call": [
       "error",
       {
-        "ignoreChainWithDepth": 4
-      }
+        ignoreChainWithDepth: 4,
+      },
     ],
     "no-array-constructor": "error",
     "no-bitwise": "error",
@@ -570,109 +563,123 @@ module.exports = {
       "error",
       {
         groups: [
-          ['%', '**'],
-          ['%', '+'],
-          ['%', '-'],
-          ['%', '*'],
-          ['%', '/'],
-          ['/', '*'],
-          ['&', '|', '<<', '>>', '>>>'],
-          ['==', '!=', '===', '!=='],
-          ['&&', '||'],
+          ["%", "**"],
+          ["%", "+"],
+          ["%", "-"],
+          ["%", "*"],
+          ["%", "/"],
+          ["/", "*"],
+          ["&", "|", "<<", ">>", ">>>"],
+          ["==", "!=", "===", "!=="],
+          ["&&", "||"],
         ],
-        allowSamePrecedence: false
-      }
+        allowSamePrecedence: false,
+      },
     ],
     "no-mixed-spaces-and-tabs": "error",
     "no-multi-assign": "error",
     "no-multiple-empty-lines": [
       "error",
       {
-        "max": 2,
-        "maxBOF": 1,
-        "maxEOF": 0
-      }
+        max: 2,
+        maxBOF: 1,
+        maxEOF: 0,
+      },
     ],
     "no-negated-condition": "off",
     "no-nested-ternary": "error",
     "no-new-object": "error",
     "no-plusplus": "off",
     "no-restricted-syntax": [
-      'error',
+      "error",
       {
-        selector: 'ForInStatement',
-        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+        selector: "ForInStatement",
+        message:
+          "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
       },
       {
-        selector: 'ForOfStatement',
-        message: 'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+        selector: "ForOfStatement",
+        message:
+          "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.",
       },
       {
-        selector: 'LabeledStatement',
-        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+        selector: "LabeledStatement",
+        message:
+          "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
       },
       {
-        selector: 'WithStatement',
-        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+        selector: "WithStatement",
+        message:
+          "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
       },
     ],
     "no-spaced-func": "error",
     "no-tabs": "error",
     "no-ternary": "off",
-    "no-trailing-spaces": ['error', {
-      skipBlankLines: false,
-      ignoreComments: false,
-    }],
+    "no-trailing-spaces": [
+      "error",
+      {
+        skipBlankLines: false,
+        ignoreComments: false,
+      },
+    ],
     "no-underscore-dangle": [
       "off",
       {
-        "allowAfterThis": false
-      }
+        allowAfterThis: false,
+      },
     ],
     "no-unneeded-ternary": [
       "error",
       {
-        "defaultAssignment": false
-      }
+        defaultAssignment: false,
+      },
     ],
     "no-whitespace-before-property": "error",
-    "nonblock-statement-body-position": ['error', 'beside', { overrides: {} }],
-    "object-curly-spacing": [
+    "nonblock-statement-body-position": ["error", "beside", { overrides: {} }],
+    "object-curly-spacing": ["error", "always"],
+    "object-curly-newline": [
       "error",
-      "always"
+      {
+        ObjectExpression: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+        ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
+        ImportDeclaration: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+        ExportDeclaration: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+      },
     ],
-    "object-curly-newline": ['error', {
-      ObjectExpression: { minProperties: 4, multiline: true, consistent: true },
-      ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
-      ImportDeclaration: { minProperties: 4, multiline: true, consistent: true },
-      ExportDeclaration: { minProperties: 4, multiline: true, consistent: true },
-    }],
     "object-property-newline": [
       "error",
       {
-        "allowMultiplePropertiesPerLine": true
-      }
+        allowMultiplePropertiesPerLine: true,
+      },
     ],
-    "one-var": [
+    "one-var": ["error", "never"],
+    "one-var-declaration-per-line": ["error", "always"],
+    "operator-assignment": ["error", "always"],
+    "operator-linebreak": ["error", "before", { overrides: { "=": "none" } }],
+    "padded-blocks": [
       "error",
-      "never"
+      {
+        blocks: "never",
+        classes: "never",
+        switches: "never",
+      },
+      {
+        allowSingleLineBlocks: true,
+      },
     ],
-    "one-var-declaration-per-line": [
-      "error",
-      "always"
-    ],
-    "operator-assignment": [
-      "error",
-      "always"
-    ],
-    "operator-linebreak": ['error', 'before', { overrides: { '=': 'none' } }],
-    "padded-blocks": ['error', {
-      blocks: 'never',
-      classes: 'never',
-      switches: 'never',
-    }, {
-      allowSingleLineBlocks: true,
-    }],
     "padding-line-between-statements": "off",
     "prefer-exponentiation-operator": "error",
     "prefer-object-spread": "error",
@@ -680,89 +687,82 @@ module.exports = {
       "error",
       "as-needed",
       {
-        "keywords": false,
-        "unnecessary": true,
-        "numbers": false
-      }
+        keywords: false,
+        unnecessary: true,
+        numbers: false,
+      },
     ],
-    "quotes": [
+    quotes: [
       "error",
       "single",
       {
-        "avoidEscape": true
-      }
+        avoidEscape: true,
+      },
     ],
     "require-jsdoc": "off",
-    "semi": [
-      "error",
-      "always"
-    ],
+    semi: ["error", "always"],
     "semi-spacing": [
       "error",
       {
-        "before": false,
-        "after": true
-      }
+        before: false,
+        after: true,
+      },
     ],
     "semi-style": ["error", "last"],
     "sort-keys": [
       "off",
       "asc",
       {
-        "caseSensitive": false,
-        "natural": true
-      }
+        caseSensitive: false,
+        natural: true,
+      },
     ],
     "sort-vars": "off",
     "space-before-blocks": "error",
     "space-before-function-paren": [
       "error",
       {
-        "anonymous": "always",
-        "named": "never",
-        "asyncArrow": "always"
-      }
+        anonymous: "always",
+        named: "never",
+        asyncArrow: "always",
+      },
     ],
-    "space-in-parens": [
-      "error",
-      "never"
-    ],
+    "space-in-parens": ["error", "never"],
     "space-infix-ops": "error",
     "space-unary-ops": [
       "error",
       {
-        "words": true,
-        "nonwords": false,
-        "overrides": {}
-      }
+        words: true,
+        nonwords: false,
+        overrides: {},
+      },
     ],
     "spaced-comment": [
       "error",
       "always",
       {
         line: {
-          exceptions: ['-', '+'],
-          markers: ['=', '!'], // space here to support sprockets directives
+          exceptions: ["-", "+"],
+          markers: ["=", "!"], // space here to support sprockets directives
         },
         block: {
-          exceptions: ['-', '+'],
-          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
+          exceptions: ["-", "+"],
+          markers: ["=", "!", ":", "::"], // space here to support sprockets directives and flow comment types
           balanced: true,
-        }
-      }
+        },
+      },
     ],
     "switch-colon-spacing": ["error", { after: true, before: false }],
     "template-tag-spacing": ["error", "never"],
-    "unicode-bom": [
-      "error",
-      "never"
-    ],
+    "unicode-bom": ["error", "never"],
     "wrap-regex": "off",
     "init-declarations": "off",
     "no-catch-shadow": "off",
     "no-delete-var": "error",
     "no-label-var": "error",
-    "no-restricted-globals": ['error', 'isFinite', 'isNaN'].concat(confusingBrowserGlobals),
+    "no-restricted-globals": ["error", "isFinite", "isNaN"].concat(
+      confusingBrowserGlobals
+    ),
     "no-shadow": "error",
     "no-shadow-restricted-names": "error",
     "no-undef": "error",
@@ -771,136 +771,136 @@ module.exports = {
     "no-unused-vars": [
       "error",
       {
-        "vars": "all",
-        "args": "after-used",
-        "ignoreRestSiblings": true
-      }
+        vars: "all",
+        args: "after-used",
+        ignoreRestSiblings: true,
+      },
     ],
-    "no-use-before-define": ["error", { functions: true, classes: true, variables: true }],
+    "no-use-before-define": [
+      "error",
+      { functions: true, classes: true, variables: true },
+    ],
     "arrow-body-style": [
       "error",
-      "as-needed", {
+      "as-needed",
+      {
         requireReturnForObjectLiteral: false,
-      }
+      },
     ],
     "arrow-parens": [
       "error",
       "as-needed",
       {
-        "requireForBlockBody": true
-      }
+        requireForBlockBody: true,
+      },
     ],
     "arrow-spacing": [
       "error",
       {
-        "before": true,
-        "after": true
-      }
+        before: true,
+        after: true,
+      },
     ],
     "constructor-super": "error",
     "generator-star-spacing": [
       "error",
       {
-        "before": false,
-        "after": true
-      }
+        before: false,
+        after: true,
+      },
     ],
     "no-class-assign": "error",
     "no-confusing-arrow": [
       "error",
       {
-        "allowParens": true
-      }
+        allowParens: true,
+      },
     ],
     "no-const-assign": "error",
     "no-dupe-class-members": "error",
     "no-duplicate-imports": "off",
     "no-new-symbol": "error",
-    "no-restricted-imports": ['off', {
-      paths: [],
-      patterns: []
-    }],
+    "no-restricted-imports": [
+      "off",
+      {
+        paths: [],
+        patterns: [],
+      },
+    ],
     "no-this-before-super": "error",
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
     "no-useless-rename": [
       "error",
       {
-        "ignoreDestructuring": false,
-        "ignoreImport": false,
-        "ignoreExport": false
-      }
+        ignoreDestructuring: false,
+        ignoreImport: false,
+        ignoreExport: false,
+      },
     ],
     "no-var": "error",
     "object-shorthand": [
       "error",
       "always",
       {
-        "ignoreConstructors": false,
-        "avoidQuotes": true
-      }
+        ignoreConstructors: false,
+        avoidQuotes: true,
+      },
     ],
     "prefer-arrow-callback": [
       "error",
       {
-        "allowNamedFunctions": false,
-        "allowUnboundThis": true
-      }
+        allowNamedFunctions: false,
+        allowUnboundThis: true,
+      },
     ],
     "prefer-const": [
       "error",
       {
-        "destructuring": "any",
-        "ignoreReadBeforeAssign": true
-      }
+        destructuring: "any",
+        ignoreReadBeforeAssign: true,
+      },
     ],
-    "prefer-destructuring": ["error", {
-      VariableDeclarator: {
-        array: false,
-        object: true,
+    "prefer-destructuring": [
+      "error",
+      {
+        VariableDeclarator: {
+          array: false,
+          object: true,
+        },
+        AssignmentExpression: {
+          array: false,
+          object: false,
+        },
       },
-      AssignmentExpression: {
-        array: true,
-        object: false,
+      {
+        enforceForRenamedProperties: false,
       },
-    }, {
-      enforceForRenamedProperties: false,
-    }],
+    ],
     "prefer-numeric-literals": "error",
     "prefer-reflect": "off",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
     "require-yield": "error",
-    "rest-spread-spacing": [
-      "error",
-      "never"
-    ],
+    "rest-spread-spacing": ["error", "never"],
     "sort-imports": [
       "off",
       {
-        "ignoreCase": false,
-        "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": [
-          "none",
-          "all",
-          "multiple",
-          "single"
-        ]
-      }
+        ignoreCase: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+      },
     ],
     "symbol-description": "error",
     "template-curly-spacing": "error",
-    "yield-star-spacing": [
-      "error",
-      "after"
-    ],
+    "yield-star-spacing": ["error", "after"],
     "import/no-unresolved": [
       "off",
       {
-        "commonjs": true,
-        "caseSensitive": true
-      }
+        commonjs: true,
+        caseSensitive: true,
+      },
     ],
     "import/named": "error",
     "import/default": "off",
@@ -913,39 +913,36 @@ module.exports = {
       "error",
       {
         devDependencies: [
-          'test/**', // tape, common npm pattern
-          'tests/**', // also common npm pattern
-          'spec/**', // mocha, rspec-like pattern
-          '**/__tests__/**', // jest pattern
-          '**/__mocks__/**', // jest pattern
-          'test.{js,jsx}', // repos with a single test file
-          'test-*.{js,jsx}', // repos with multiple top-level test files
-          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
-          '**/jest.config.js', // jest config
-          '**/jest.setup.js', // jest setup
-          '**/vue.config.js', // vue-cli config
-          '**/webpack.config.js', // webpack config
-          '**/webpack.config.*.js', // webpack config
-          '**/rollup.config.js', // rollup config
-          '**/rollup.config.*.js', // rollup config
-          '**/gulpfile.js', // gulp config
-          '**/gulpfile.*.js', // gulp config
-          '**/Gruntfile{,.js}', // grunt config
-          '**/protractor.conf.js', // protractor config
-          '**/protractor.conf.*.js', // protractor config
-          '**/karma.conf.js' // karma config
+          "test/**", // tape, common npm pattern
+          "tests/**", // also common npm pattern
+          "spec/**", // mocha, rspec-like pattern
+          "**/__tests__/**", // jest pattern
+          "**/__mocks__/**", // jest pattern
+          "test.{js,jsx}", // repos with a single test file
+          "test-*.{js,jsx}", // repos with multiple top-level test files
+          "**/*{.,_}{test,spec}.{js,jsx}", // tests where the extension or filename suffix denotes that it is a test
+          "**/jest.config.js", // jest config
+          "**/jest.setup.js", // jest setup
+          "**/vue.config.js", // vue-cli config
+          "**/webpack.config.js", // webpack config
+          "**/webpack.config.*.js", // webpack config
+          "**/rollup.config.js", // rollup config
+          "**/rollup.config.*.js", // rollup config
+          "**/gulpfile.js", // gulp config
+          "**/gulpfile.*.js", // gulp config
+          "**/Gruntfile{,.js}", // grunt config
+          "**/protractor.conf.js", // protractor config
+          "**/protractor.conf.*.js", // protractor config
+          "**/karma.conf.js", // karma config
         ],
         optionalDependencies: false,
-      }
+      },
     ],
     "import/no-mutable-exports": "error",
     "import/no-commonjs": "off",
     "import/no-amd": "error",
     "import/no-nodejs-modules": "off",
-    "import/first": [
-      "error",
-      "absolute-first"
-    ],
+    "import/first": ["error", "absolute-first"],
     "import/imports-first": "off",
     "import/no-duplicates": "error",
     "import/no-namespace": "off",
@@ -953,41 +950,47 @@ module.exports = {
       "error",
       "ignorePackages",
       {
-        "js": "never",
-        "mjs": "never",
-        "jsx": "never"
-      }
+        js: "never",
+        mjs: "never",
+        jsx: "never",
+      },
     ],
-    "import/order": ['error', { groups: [['builtin', 'external', 'internal']] }],
+    "import/order": [
+      "error",
+      { groups: [["builtin", "external", "internal"]] },
+    ],
     "import/newline-after-import": "error",
     "import/prefer-default-export": "error",
     "import/no-restricted-paths": "off",
     "import/max-dependencies": [
       "off",
       {
-        "max": 10
-      }
+        max: 10,
+      },
     ],
     "import/no-absolute-path": "error",
     "import/no-dynamic-require": "error",
     "import/no-internal-modules": [
       "off",
       {
-        "allow": []
-      }
+        allow: [],
+      },
     ],
     "import/unambiguous": "off",
     "import/no-webpack-loader-syntax": "error",
     "import/no-unassigned-import": "off",
     "import/no-named-default": "error",
-    "import/no-anonymous-default-export": ["off", {
-      allowArray: false,
-      allowArrowFunction: false,
-      allowAnonymousClass: false,
-      allowAnonymousFunction: false,
-      allowLiteral: false,
-      allowObject: false,
-    }],
+    "import/no-anonymous-default-export": [
+      "off",
+      {
+        allowArray: false,
+        allowArrowFunction: false,
+        allowAnonymousClass: false,
+        allowAnonymousFunction: false,
+        allowLiteral: false,
+        allowObject: false,
+      },
+    ],
     "import/exports-last": "off",
     "import/group-exports": "off",
     "import/no-default-export": "off",
@@ -995,16 +998,22 @@ module.exports = {
     "import/no-self-import": "error",
     "import/no-cycle": ["error", { maxDepth: Infinity }],
     "import/no-useless-path-segments": ["error", { commonjs: true }],
-    "import/dynamic-import-chunkname": ["off", {
-      importFunctions: [],
-      webpackChunknameFormat: "[0-9a-zA-Z-_/.]+",
-    }],
+    "import/dynamic-import-chunkname": [
+      "off",
+      {
+        importFunctions: [],
+        webpackChunknameFormat: "[0-9a-zA-Z-_/.]+",
+      },
+    ],
     "import/no-relative-parent-imports": "off",
-    "import/no-unused-modules": ["off", {
-      ignoreExports: [],
-      missingExports: true,
-      unusedExports: true,
-    }],
-    "strict": ["error", "never"]
-  }
+    "import/no-unused-modules": [
+      "off",
+      {
+        ignoreExports: [],
+        missingExports: true,
+        unusedExports: true,
+      },
+    ],
+    strict: ["error", "never"],
+  },
 };

--- a/kintent-rules.js
+++ b/kintent-rules.js
@@ -1,67 +1,80 @@
-const confusingBrowserGlobals = require("confusing-browser-globals");
+const confusingBrowserGlobals = require('confusing-browser-globals');
 
 module.exports = {
-  env: {
-    node: true,
-    es2020: true,
-    mocha: true,
+  "env": {
+    "node": true,
+    "es2020": true,
+    "mocha": true
   },
-  globals: {
-    assert: false,
-    expect: false,
-    should: false,
+  "globals": {
+    "assert": false,
+    "expect": false,
+    "should": false
   },
-  parserOptions: {
-    ecmaFeatures: {
-      generators: false,
-      objectLiteralDuplicateProperties: false,
+  "parserOptions": {
+    "ecmaFeatures": {
+      "generators": false,
+      "objectLiteralDuplicateProperties": false
     },
-    ecmaVersion: 2020,
-    sourceType: "module",
+    "ecmaVersion": 2020,
+    "sourceType": "module"
   },
-  plugins: ["import"],
+  "plugins": [
+    'import'
+  ],
 
-  settings: {
-    "import/resolver": {
+  "settings": {
+    'import/resolver': {
       node: {
-        extensions: [".mjs", ".js", ".json"],
-      },
+        extensions: ['.mjs', '.js', '.json']
+      }
     },
-    "import/extensions": [".js", ".mjs", ".jsx"],
-    "import/core-modules": [],
-    "import/ignore": [
-      "node_modules",
-      "\\.(coffee|scss|css|less|hbs|svg|json)$",
+    'import/extensions': [
+      '.js',
+      '.mjs',
+      '.jsx',
+    ],
+    'import/core-modules': [
+    ],
+    'import/ignore': [
+      'node_modules',
+      '\\.(coffee|scss|css|less|hbs|svg|json)$',
     ],
   },
-  rules: {
+  "rules": {
     "accessor-pairs": "off",
     "array-callback-return": ["error", { allowImplicit: true }],
     "block-scoped-var": "error",
-    complexity: ["warn", 11],
-    "class-methods-use-this": [
-      "error",
-      {
-        exceptMethods: [],
-      },
+    "complexity": [
+      "warn",
+      11
     ],
+    "class-methods-use-this": ['error', {
+      exceptMethods: [],
+    }],
     "consistent-return": "error",
-    curly: ["error", "multi-line"],
+    "curly": [
+      "error",
+      "multi-line"
+    ],
     "default-case": [
       "error",
       {
-        commentPattern: "^no default$",
-      },
+        "commentPattern": "^no default$"
+      }
     ],
     "default-param-last": "off",
     "dot-notation": [
       "error",
       {
-        allowKeywords: true,
-      },
+        "allowKeywords": true
+      }
     ],
-    "dot-location": ["error", "property"],
-    eqeqeq: ["error", "always", { null: "ignore" }],
+    "dot-location": [
+      "error",
+      "property"
+    ],
+    "eqeqeq": ["error", "always", { null: "ignore" }],
     "grouped-accessor-pairs": "error",
     "guard-for-in": "error",
     "max-classes-per-file": ["error", 1],
@@ -74,8 +87,12 @@ module.exports = {
     "no-empty-function": [
       "error",
       {
-        allow: ["arrowFunctions", "functions", "methods"],
-      },
+        "allow": [
+          "arrowFunctions",
+          "functions",
+          "methods"
+        ]
+      }
     ],
     "no-empty-pattern": "error",
     "no-eq-null": "off",
@@ -88,18 +105,18 @@ module.exports = {
     "no-global-assign": [
       "error",
       {
-        exceptions: [],
-      },
+        "exceptions": []
+      }
     ],
     "no-native-reassign": "off",
     "no-implicit-coercion": [
       "off",
       {
-        boolean: false,
-        number: true,
-        string: true,
-        allow: [],
-      },
+        "boolean": false,
+        "number": true,
+        "string": true,
+        "allow": []
+      }
     ],
     "no-implicit-globals": "off",
     "no-implied-eval": "error",
@@ -108,27 +125,24 @@ module.exports = {
     "no-labels": [
       "error",
       {
-        allowLoop: false,
-        allowSwitch: false,
-      },
+        "allowLoop": false,
+        "allowSwitch": false
+      }
     ],
     "no-lone-blocks": "error",
     "no-loop-func": "error",
     "no-magic-numbers": [
       "off",
       {
-        ignore: [],
-        ignoreArrayIndexes: true,
-        enforceConst: true,
-        detectObjects: false,
-      },
+        "ignore": [],
+        "ignoreArrayIndexes": true,
+        "enforceConst": true,
+        "detectObjects": false
+      }
     ],
-    "no-multi-spaces": [
-      "error",
-      {
-        ignoreEOLComments: false,
-      },
-    ],
+    "no-multi-spaces": ["error", {
+      ignoreEOLComments: false,
+    }],
     "no-multi-str": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -138,66 +152,51 @@ module.exports = {
     "no-param-reassign": "error",
     "no-proto": "error",
     "no-redeclare": "error",
-    "no-restricted-properties": [
-      "error",
-      {
-        object: "arguments",
-        property: "callee",
-        message: "arguments.callee is deprecated",
-      },
-      {
-        object: "global",
-        property: "isFinite",
-        message: "Please use Number.isFinite instead",
-      },
-      {
-        object: "self",
-        property: "isFinite",
-        message: "Please use Number.isFinite instead",
-      },
-      {
-        object: "window",
-        property: "isFinite",
-        message: "Please use Number.isFinite instead",
-      },
-      {
-        object: "global",
-        property: "isNaN",
-        message: "Please use Number.isNaN instead",
-      },
-      {
-        object: "self",
-        property: "isNaN",
-        message: "Please use Number.isNaN instead",
-      },
-      {
-        object: "window",
-        property: "isNaN",
-        message: "Please use Number.isNaN instead",
-      },
-      {
-        property: "__defineGetter__",
-        message: "Please use Object.defineProperty instead.",
-      },
-      {
-        property: "__defineSetter__",
-        message: "Please use Object.defineProperty instead.",
-      },
-      {
-        object: "Math",
-        property: "pow",
-        message: "Use the exponentiation operator (**) instead.",
-      },
-    ],
+    "no-restricted-properties": ["error", {
+      object: "arguments",
+      property: "callee",
+      message: "arguments.callee is deprecated",
+    }, {
+      object: "global",
+      property: "isFinite",
+      message: "Please use Number.isFinite instead",
+    }, {
+      object: "self",
+      property: "isFinite",
+      message: "Please use Number.isFinite instead",
+    }, {
+      object: "window",
+      property: "isFinite",
+      message: "Please use Number.isFinite instead",
+    }, {
+      object: "global",
+      property: "isNaN",
+      message: "Please use Number.isNaN instead",
+    }, {
+      object: "self",
+      property: "isNaN",
+      message: "Please use Number.isNaN instead",
+    }, {
+      object: "window",
+      property: "isNaN",
+      message: "Please use Number.isNaN instead",
+    }, {
+      property: "__defineGetter__",
+      message: "Please use Object.defineProperty instead.",
+    }, {
+      property: "__defineSetter__",
+      message: "Please use Object.defineProperty instead.",
+    }, {
+      object: "Math",
+      property: "pow",
+      message: "Use the exponentiation operator (**) instead.",
+    }],
     "no-return-assign": ["error", "always"],
     "no-script-url": "error",
     "no-return-await": "error",
-    "no-self-assign": [
-      "error",
-      {
-        props: true,
-      },
-    ],
+    "no-self-assign": ["error", {
+      props: true,
+    }],
     "no-self-compare": "error",
     "no-sequences": "error",
     "no-throw-literal": "error",
@@ -205,10 +204,10 @@ module.exports = {
     "no-unused-expressions": [
       "error",
       {
-        allowShortCircuit: false,
-        allowTernary: false,
-        allowTaggedTemplates: false,
-      },
+        "allowShortCircuit": false,
+        "allowTernary": false,
+        "allowTaggedTemplates": false
+      }
     ],
     "no-unused-labels": "error",
     "no-useless-call": "off",
@@ -220,32 +219,39 @@ module.exports = {
     "no-warning-comments": [
       "off",
       {
-        terms: ["todo", "fixme", "xxx"],
-        location: "start",
-      },
+        "terms": [
+          "todo",
+          "fixme",
+          "xxx"
+        ],
+        "location": "start"
+      }
     ],
     "no-with": "error",
     "prefer-promise-reject-errors": ["error", { allowEmptyReject: true }],
     "prefer-named-capture-group": "off",
     "prefer-regex-literals": "error",
-    radix: "error",
-    "require-await": "off", // note: this is a horrible rule that should never be use
+    "radix": "error",
+    "require-await": "off",       // note: this is a horrible rule that should never be use
     "require-unicode-regexp": "off",
     "vars-on-top": "error",
     "wrap-iife": [
       "error",
       "outside",
       {
-        functionPrototypeMethods: false,
-      },
+        "functionPrototypeMethods": false
+      }
     ],
-    yoda: "error",
+    "yoda": "error",
     "for-direction": "error",
     "getter-return": ["error", { allowImplicit: true }],
     "no-async-promise-executor": "error",
     "no-await-in-loop": "error",
     "no-compare-neg-zero": "error",
-    "no-cond-assign": ["error", "always"],
+    "no-cond-assign": [
+      "error",
+      "always"
+    ],
     "no-console": "warn",
     "no-constant-condition": "warn",
     "no-control-regex": "error",
@@ -262,12 +268,12 @@ module.exports = {
       "off",
       "all",
       {
-        conditionalAssign: true,
-        nestedBinaryExpressions: false,
-        returnAssign: false,
-        ignoreJSX: "all",
-        enforceForArrowConditionals: false,
-      },
+        "conditionalAssign": true,
+        "nestedBinaryExpressions": false,
+        "returnAssign": false,
+        "ignoreJSX": "all",
+        "enforceForArrowConditionals": false
+      }
     ],
     "no-extra-semi": "error",
     "no-func-assign": "error",
@@ -293,14 +299,17 @@ module.exports = {
     "valid-typeof": [
       "error",
       {
-        requireStringLiterals: true,
-      },
+        "requireStringLiterals": true
+      }
     ],
     "callback-return": "off",
     "global-require": "warn",
     "handle-callback-err": "off",
     "no-buffer-constructor": "error",
-    "no-mixed-requires": ["off", false],
+    "no-mixed-requires": [
+      "off",
+      false
+    ],
     "no-new-require": "error",
     "no-path-concat": "error",
     "no-process-env": "off",
@@ -309,59 +318,57 @@ module.exports = {
     "no-sync": "off",
     "array-bracket-newline": ["off", "consistent"],
     "array-element-newline": ["off", { multiline: true, minItems: 3 }],
-    "array-bracket-spacing": ["error", "never"],
-    "block-spacing": ["error", "always"],
+    "array-bracket-spacing": [
+      "error",
+      "never"
+    ],
+    "block-spacing": [
+      "error",
+      "always"
+    ],
     "brace-style": [
       "error",
       "1tbs",
       {
-        allowSingleLine: true,
-      },
+        "allowSingleLine": true
+      }
     ],
-    camelcase: [
+    "camelcase": [
       "error",
       {
-        properties: "never",
-        ignoreDestructuring: false,
-      },
+        "properties": "never",
+        "ignoreDestructuring": false
+      }
     ],
-    "capitalized-comments": [
-      "off",
-      "never",
-      {
-        line: {
-          ignorePattern: ".*",
-          ignoreInlineComments: true,
-          ignoreConsecutiveComments: true,
-        },
-        block: {
-          ignorePattern: ".*",
-          ignoreInlineComments: true,
-          ignoreConsecutiveComments: true,
-        },
+    "capitalized-comments": ["off", "never", {
+      line: {
+        ignorePattern: ".*",
+        ignoreInlineComments: true,
+        ignoreConsecutiveComments: true,
       },
-    ],
-    "comma-dangle": [
-      "off",
-      {
-        arrays: "always-multiline",
-        objects: "always-multiline",
-        imports: "always-multiline",
-        exports: "always-multiline",
-        functions: "always-multiline",
+      block: {
+        ignorePattern: '.*',
+        ignoreInlineComments: true,
+        ignoreConsecutiveComments: true,
       },
-    ],
+    }],
+    "comma-dangle": ["off", {
+      arrays: "always-multiline",
+      objects: "always-multiline",
+      imports: "always-multiline",
+      exports: "always-multiline",
+      functions: "always-multiline",
+    }],
     "comma-spacing": [
       "error",
       {
-        before: false,
-        after: true,
-      },
+        "before": false,
+        "after": true
+      }
     ],
     "comma-style": [
       "error",
-      "last",
-      {
+      "last", {
         exceptions: {
           ArrayExpression: false,
           ArrayPattern: false,
@@ -374,176 +381,176 @@ module.exports = {
           ObjectPattern: false,
           VariableDeclaration: false,
           NewExpression: false,
-        },
-      },
+        }
+      }
     ],
-    "computed-property-spacing": ["error", "never"],
+    "computed-property-spacing": [
+      "error",
+      "never"
+    ],
     "consistent-this": "off",
-    "eol-last": ["error", "always"],
+    "eol-last": [
+      "error",
+      "always"
+    ],
     "function-call-argument-newline": ["off", "consistent"],
-    "func-call-spacing": ["error", "never"],
+    "func-call-spacing": [
+      "error",
+      "never"
+    ],
     "func-name-matching": [
       "off",
       "always",
       {
         includeCommonJSModuleExports: false,
         considerPropertyDescriptor: true,
-      },
+      }
     ],
     "func-names": "warn",
     "func-style": [
       "error",
-      "declaration",
-      {
-        allowArrowFunctions: true,
-      },
+      "declaration", {
+        allowArrowFunctions: true
+      }
     ],
     "function-paren-newline": ["error", "consistent"],
     "id-blacklist": "off",
     "id-length": "off",
     "id-match": "off",
     "implicit-arrow-linebreak": ["error", "beside"],
-    indent: [
+    "indent": [
       "error",
       2,
       {
-        SwitchCase: 1,
-        VariableDeclarator: 1,
-        outerIIFEBody: 1,
-        FunctionDeclaration: {
-          parameters: 1,
-          body: 1,
+        "SwitchCase": 1,
+        "VariableDeclarator": 1,
+        "outerIIFEBody": 1,
+        "FunctionDeclaration": {
+          "parameters": 1,
+          "body": 1
         },
-        FunctionExpression: {
-          parameters: 1,
-          body: 1,
+        "FunctionExpression": {
+          "parameters": 1,
+          "body": 1
         },
         CallExpression: {
-          arguments: 1,
+          arguments: 1
         },
         ArrayExpression: 1,
         ObjectExpression: 1,
         ImportDeclaration: 1,
         flatTernaryExpressions: false,
-        ignoredNodes: [
-          "JSXElement",
-          "JSXElement > *",
-          "JSXAttribute",
-          "JSXIdentifier",
-          "JSXNamespacedName",
-          "JSXMemberExpression",
-          "JSXSpreadAttribute",
-          "JSXExpressionContainer",
-          "JSXOpeningElement",
-          "JSXClosingElement",
-          "JSXText",
-          "JSXEmptyExpression",
-          "JSXSpreadChild",
-        ],
-        ignoreComments: false,
-      },
+        ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
+        ignoreComments: false
+      }
     ],
-    "jsx-quotes": ["off", "prefer-double"],
+    "jsx-quotes": [
+      "off",
+      "prefer-double"
+    ],
     "key-spacing": [
       "error",
       {
-        beforeColon: false,
-        afterColon: true,
-      },
+        "beforeColon": false,
+        "afterColon": true
+      }
     ],
     "keyword-spacing": [
       "error",
       {
-        before: true,
-        after: true,
-        overrides: {
-          return: {
-            after: true,
+        "before": true,
+        "after": true,
+        "overrides": {
+          "return": {
+            "after": true
           },
-          throw: {
-            after: true,
+          "throw": {
+            "after": true
           },
-          case: {
-            after: true,
-          },
-        },
-      },
+          "case": {
+            "after": true
+          }
+        }
+      }
     ],
     "line-comment-position": [
       "off",
       {
-        position: "above",
-        ignorePattern: "",
-        applyDefaultPatterns: true,
-      },
+        "position": "above",
+        "ignorePattern": "",
+        "applyDefaultPatterns": true
+      }
     ],
-    "linebreak-style": ["error", "unix"],
-    "lines-between-class-members": [
+    "linebreak-style": [
       "error",
-      "always",
-      { exceptAfterSingleLine: false },
+      "unix"
     ],
+    "lines-between-class-members": ["error", "always", { exceptAfterSingleLine: false }],
     "lines-around-comment": "off",
     "lines-around-directive": [
       "error",
       {
-        before: "always",
-        after: "always",
-      },
+        "before": "always",
+        "after": "always"
+      }
     ],
-    "max-depth": ["off", 4],
-    "max-len": [
-      "error",
-      120,
-      2,
-      {
-        ignoreUrls: true,
-        ignoreComments: false,
-        ignoreRegExpLiterals: true,
-        ignoreStrings: true,
-        ignoreTemplateLiterals: true,
-      },
+    "max-depth": [
+      "off",
+      4
     ],
+    "max-len": ['error', 120, 2, {
+      ignoreUrls: true,
+      ignoreComments: false,
+      ignoreRegExpLiterals: true,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+    }],
     "max-lines": [
       "off",
       {
-        max: 300,
-        skipBlankLines: true,
-        skipComments: true,
-      },
+        "max": 300,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
     ],
-    "max-lines-per-function": [
-      "warn",
-      {
-        max: 50,
-        skipBlankLines: true,
-        skipComments: true,
-        IIFEs: true,
-      },
-    ],
+    "max-lines-per-function": ['warn', {
+      max: 50,
+      skipBlankLines: true,
+      skipComments: true,
+      IIFEs: true,
+    }],
     "max-nested-callbacks": "off",
-    "max-params": ["off", 3],
-    "max-statements": ["off", 10],
+    "max-params": [
+      "off",
+      3
+    ],
+    "max-statements": [
+      "off",
+      10
+    ],
     "max-statements-per-line": [
       "off",
       {
-        max: 1,
-      },
+        "max": 1
+      }
     ],
-    "multiline-comment-style": ["off", "starred-block"],
-    "multiline-ternary": ["off", "never"],
+    "multiline-comment-style": ['off', 'starred-block'],
+    "multiline-ternary": [
+      "off",
+      "never"
+    ],
     "new-cap": [
       "error",
       {
-        newIsCap: true,
-        newIsCapExceptions: [],
-        capIsNew: false,
-        capIsNewExceptions: [
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "capIsNew": false,
+        "capIsNewExceptions": [
           "Immutable.Map",
           "Immutable.Set",
-          "Immutable.List",
-        ],
-      },
+          "Immutable.List"
+        ]
+      }
     ],
     "new-parens": "error",
     "newline-after-var": "off",
@@ -551,8 +558,8 @@ module.exports = {
     "newline-per-chained-call": [
       "error",
       {
-        ignoreChainWithDepth: 4,
-      },
+        "ignoreChainWithDepth": 4
+      }
     ],
     "no-array-constructor": "error",
     "no-bitwise": "error",
@@ -563,123 +570,109 @@ module.exports = {
       "error",
       {
         groups: [
-          ["%", "**"],
-          ["%", "+"],
-          ["%", "-"],
-          ["%", "*"],
-          ["%", "/"],
-          ["/", "*"],
-          ["&", "|", "<<", ">>", ">>>"],
-          ["==", "!=", "===", "!=="],
-          ["&&", "||"],
+          ['%', '**'],
+          ['%', '+'],
+          ['%', '-'],
+          ['%', '*'],
+          ['%', '/'],
+          ['/', '*'],
+          ['&', '|', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!=='],
+          ['&&', '||'],
         ],
-        allowSamePrecedence: false,
-      },
+        allowSamePrecedence: false
+      }
     ],
     "no-mixed-spaces-and-tabs": "error",
     "no-multi-assign": "error",
     "no-multiple-empty-lines": [
       "error",
       {
-        max: 2,
-        maxBOF: 1,
-        maxEOF: 0,
-      },
+        "max": 2,
+        "maxBOF": 1,
+        "maxEOF": 0
+      }
     ],
     "no-negated-condition": "off",
     "no-nested-ternary": "error",
     "no-new-object": "error",
     "no-plusplus": "off",
     "no-restricted-syntax": [
-      "error",
+      'error',
       {
-        selector: "ForInStatement",
-        message:
-          "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
       },
       {
-        selector: "ForOfStatement",
-        message:
-          "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.",
+        selector: 'ForOfStatement',
+        message: 'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
       },
       {
-        selector: "LabeledStatement",
-        message:
-          "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
       },
       {
-        selector: "WithStatement",
-        message:
-          "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
     "no-spaced-func": "error",
     "no-tabs": "error",
     "no-ternary": "off",
-    "no-trailing-spaces": [
-      "error",
-      {
-        skipBlankLines: false,
-        ignoreComments: false,
-      },
-    ],
+    "no-trailing-spaces": ['error', {
+      skipBlankLines: false,
+      ignoreComments: false,
+    }],
     "no-underscore-dangle": [
       "off",
       {
-        allowAfterThis: false,
-      },
+        "allowAfterThis": false
+      }
     ],
     "no-unneeded-ternary": [
       "error",
       {
-        defaultAssignment: false,
-      },
+        "defaultAssignment": false
+      }
     ],
     "no-whitespace-before-property": "error",
-    "nonblock-statement-body-position": ["error", "beside", { overrides: {} }],
-    "object-curly-spacing": ["error", "always"],
-    "object-curly-newline": [
+    "nonblock-statement-body-position": ['error', 'beside', { overrides: {} }],
+    "object-curly-spacing": [
       "error",
-      {
-        ObjectExpression: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-        ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
-        ImportDeclaration: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-        ExportDeclaration: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-      },
+      "always"
     ],
+    "object-curly-newline": ['error', {
+      ObjectExpression: { minProperties: 4, multiline: true, consistent: true },
+      ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
+      ImportDeclaration: { minProperties: 4, multiline: true, consistent: true },
+      ExportDeclaration: { minProperties: 4, multiline: true, consistent: true },
+    }],
     "object-property-newline": [
       "error",
       {
-        allowMultiplePropertiesPerLine: true,
-      },
+        "allowMultiplePropertiesPerLine": true
+      }
     ],
-    "one-var": ["error", "never"],
-    "one-var-declaration-per-line": ["error", "always"],
-    "operator-assignment": ["error", "always"],
-    "operator-linebreak": ["error", "before", { overrides: { "=": "none" } }],
-    "padded-blocks": [
+    "one-var": [
       "error",
-      {
-        blocks: "never",
-        classes: "never",
-        switches: "never",
-      },
-      {
-        allowSingleLineBlocks: true,
-      },
+      "never"
     ],
+    "one-var-declaration-per-line": [
+      "error",
+      "always"
+    ],
+    "operator-assignment": [
+      "error",
+      "always"
+    ],
+    "operator-linebreak": ['error', 'before', { overrides: { '=': 'none' } }],
+    "padded-blocks": ['error', {
+      blocks: 'never',
+      classes: 'never',
+      switches: 'never',
+    }, {
+      allowSingleLineBlocks: true,
+    }],
     "padding-line-between-statements": "off",
     "prefer-exponentiation-operator": "error",
     "prefer-object-spread": "error",
@@ -687,82 +680,89 @@ module.exports = {
       "error",
       "as-needed",
       {
-        keywords: false,
-        unnecessary: true,
-        numbers: false,
-      },
+        "keywords": false,
+        "unnecessary": true,
+        "numbers": false
+      }
     ],
-    quotes: [
+    "quotes": [
       "error",
       "single",
       {
-        avoidEscape: true,
-      },
+        "avoidEscape": true
+      }
     ],
     "require-jsdoc": "off",
-    semi: ["error", "always"],
+    "semi": [
+      "error",
+      "always"
+    ],
     "semi-spacing": [
       "error",
       {
-        before: false,
-        after: true,
-      },
+        "before": false,
+        "after": true
+      }
     ],
     "semi-style": ["error", "last"],
     "sort-keys": [
       "off",
       "asc",
       {
-        caseSensitive: false,
-        natural: true,
-      },
+        "caseSensitive": false,
+        "natural": true
+      }
     ],
     "sort-vars": "off",
     "space-before-blocks": "error",
     "space-before-function-paren": [
       "error",
       {
-        anonymous: "always",
-        named: "never",
-        asyncArrow: "always",
-      },
+        "anonymous": "always",
+        "named": "never",
+        "asyncArrow": "always"
+      }
     ],
-    "space-in-parens": ["error", "never"],
+    "space-in-parens": [
+      "error",
+      "never"
+    ],
     "space-infix-ops": "error",
     "space-unary-ops": [
       "error",
       {
-        words: true,
-        nonwords: false,
-        overrides: {},
-      },
+        "words": true,
+        "nonwords": false,
+        "overrides": {}
+      }
     ],
     "spaced-comment": [
       "error",
       "always",
       {
         line: {
-          exceptions: ["-", "+"],
-          markers: ["=", "!"], // space here to support sprockets directives
+          exceptions: ['-', '+'],
+          markers: ['=', '!'], // space here to support sprockets directives
         },
         block: {
-          exceptions: ["-", "+"],
-          markers: ["=", "!", ":", "::"], // space here to support sprockets directives and flow comment types
+          exceptions: ['-', '+'],
+          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
           balanced: true,
-        },
-      },
+        }
+      }
     ],
     "switch-colon-spacing": ["error", { after: true, before: false }],
     "template-tag-spacing": ["error", "never"],
-    "unicode-bom": ["error", "never"],
+    "unicode-bom": [
+      "error",
+      "never"
+    ],
     "wrap-regex": "off",
     "init-declarations": "off",
     "no-catch-shadow": "off",
     "no-delete-var": "error",
     "no-label-var": "error",
-    "no-restricted-globals": ["error", "isFinite", "isNaN"].concat(
-      confusingBrowserGlobals
-    ),
+    "no-restricted-globals": ['error', 'isFinite', 'isNaN'].concat(confusingBrowserGlobals),
     "no-shadow": "error",
     "no-shadow-restricted-names": "error",
     "no-undef": "error",
@@ -771,136 +771,136 @@ module.exports = {
     "no-unused-vars": [
       "error",
       {
-        vars: "all",
-        args: "after-used",
-        ignoreRestSiblings: true,
-      },
+        "vars": "all",
+        "args": "after-used",
+        "ignoreRestSiblings": true
+      }
     ],
-    "no-use-before-define": [
-      "error",
-      { functions: true, classes: true, variables: true },
-    ],
+    "no-use-before-define": ["error", { functions: true, classes: true, variables: true }],
     "arrow-body-style": [
       "error",
-      "as-needed",
-      {
+      "as-needed", {
         requireReturnForObjectLiteral: false,
-      },
+      }
     ],
     "arrow-parens": [
       "error",
       "as-needed",
       {
-        requireForBlockBody: true,
-      },
+        "requireForBlockBody": true
+      }
     ],
     "arrow-spacing": [
       "error",
       {
-        before: true,
-        after: true,
-      },
+        "before": true,
+        "after": true
+      }
     ],
     "constructor-super": "error",
     "generator-star-spacing": [
       "error",
       {
-        before: false,
-        after: true,
-      },
+        "before": false,
+        "after": true
+      }
     ],
     "no-class-assign": "error",
     "no-confusing-arrow": [
       "error",
       {
-        allowParens: true,
-      },
+        "allowParens": true
+      }
     ],
     "no-const-assign": "error",
     "no-dupe-class-members": "error",
     "no-duplicate-imports": "off",
     "no-new-symbol": "error",
-    "no-restricted-imports": [
-      "off",
-      {
-        paths: [],
-        patterns: [],
-      },
-    ],
+    "no-restricted-imports": ['off', {
+      paths: [],
+      patterns: []
+    }],
     "no-this-before-super": "error",
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
     "no-useless-rename": [
       "error",
       {
-        ignoreDestructuring: false,
-        ignoreImport: false,
-        ignoreExport: false,
-      },
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
     ],
     "no-var": "error",
     "object-shorthand": [
       "error",
       "always",
       {
-        ignoreConstructors: false,
-        avoidQuotes: true,
-      },
+        "ignoreConstructors": false,
+        "avoidQuotes": true
+      }
     ],
     "prefer-arrow-callback": [
       "error",
       {
-        allowNamedFunctions: false,
-        allowUnboundThis: true,
-      },
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
     ],
     "prefer-const": [
       "error",
       {
-        destructuring: "any",
-        ignoreReadBeforeAssign: true,
-      },
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": true
+      }
     ],
-    "prefer-destructuring": [
-      "error",
-      {
-        VariableDeclarator: {
-          array: false,
-          object: true,
-        },
-        AssignmentExpression: {
-          array: false,
-          object: false,
-        },
+    "prefer-destructuring": ["error", {
+      VariableDeclarator: {
+        array: false,
+        object: true,
       },
-      {
-        enforceForRenamedProperties: false,
+      AssignmentExpression: {
+        array: false,
+        object: false,
       },
-    ],
+    }, {
+      enforceForRenamedProperties: false,
+    }],
     "prefer-numeric-literals": "error",
     "prefer-reflect": "off",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
     "require-yield": "error",
-    "rest-spread-spacing": ["error", "never"],
+    "rest-spread-spacing": [
+      "error",
+      "never"
+    ],
     "sort-imports": [
       "off",
       {
-        ignoreCase: false,
-        ignoreMemberSort: false,
-        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
-      },
+        "ignoreCase": false,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": [
+          "none",
+          "all",
+          "multiple",
+          "single"
+        ]
+      }
     ],
     "symbol-description": "error",
     "template-curly-spacing": "error",
-    "yield-star-spacing": ["error", "after"],
+    "yield-star-spacing": [
+      "error",
+      "after"
+    ],
     "import/no-unresolved": [
       "off",
       {
-        commonjs: true,
-        caseSensitive: true,
-      },
+        "commonjs": true,
+        "caseSensitive": true
+      }
     ],
     "import/named": "error",
     "import/default": "off",
@@ -913,36 +913,39 @@ module.exports = {
       "error",
       {
         devDependencies: [
-          "test/**", // tape, common npm pattern
-          "tests/**", // also common npm pattern
-          "spec/**", // mocha, rspec-like pattern
-          "**/__tests__/**", // jest pattern
-          "**/__mocks__/**", // jest pattern
-          "test.{js,jsx}", // repos with a single test file
-          "test-*.{js,jsx}", // repos with multiple top-level test files
-          "**/*{.,_}{test,spec}.{js,jsx}", // tests where the extension or filename suffix denotes that it is a test
-          "**/jest.config.js", // jest config
-          "**/jest.setup.js", // jest setup
-          "**/vue.config.js", // vue-cli config
-          "**/webpack.config.js", // webpack config
-          "**/webpack.config.*.js", // webpack config
-          "**/rollup.config.js", // rollup config
-          "**/rollup.config.*.js", // rollup config
-          "**/gulpfile.js", // gulp config
-          "**/gulpfile.*.js", // gulp config
-          "**/Gruntfile{,.js}", // grunt config
-          "**/protractor.conf.js", // protractor config
-          "**/protractor.conf.*.js", // protractor config
-          "**/karma.conf.js", // karma config
+          'test/**', // tape, common npm pattern
+          'tests/**', // also common npm pattern
+          'spec/**', // mocha, rspec-like pattern
+          '**/__tests__/**', // jest pattern
+          '**/__mocks__/**', // jest pattern
+          'test.{js,jsx}', // repos with a single test file
+          'test-*.{js,jsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/jest.config.js', // jest config
+          '**/jest.setup.js', // jest setup
+          '**/vue.config.js', // vue-cli config
+          '**/webpack.config.js', // webpack config
+          '**/webpack.config.*.js', // webpack config
+          '**/rollup.config.js', // rollup config
+          '**/rollup.config.*.js', // rollup config
+          '**/gulpfile.js', // gulp config
+          '**/gulpfile.*.js', // gulp config
+          '**/Gruntfile{,.js}', // grunt config
+          '**/protractor.conf.js', // protractor config
+          '**/protractor.conf.*.js', // protractor config
+          '**/karma.conf.js' // karma config
         ],
         optionalDependencies: false,
-      },
+      }
     ],
     "import/no-mutable-exports": "error",
     "import/no-commonjs": "off",
     "import/no-amd": "error",
     "import/no-nodejs-modules": "off",
-    "import/first": ["error", "absolute-first"],
+    "import/first": [
+      "error",
+      "absolute-first"
+    ],
     "import/imports-first": "off",
     "import/no-duplicates": "error",
     "import/no-namespace": "off",
@@ -950,47 +953,41 @@ module.exports = {
       "error",
       "ignorePackages",
       {
-        js: "never",
-        mjs: "never",
-        jsx: "never",
-      },
+        "js": "never",
+        "mjs": "never",
+        "jsx": "never"
+      }
     ],
-    "import/order": [
-      "error",
-      { groups: [["builtin", "external", "internal"]] },
-    ],
+    "import/order": ['error', { groups: [['builtin', 'external', 'internal']] }],
     "import/newline-after-import": "error",
     "import/prefer-default-export": "error",
     "import/no-restricted-paths": "off",
     "import/max-dependencies": [
       "off",
       {
-        max: 10,
-      },
+        "max": 10
+      }
     ],
     "import/no-absolute-path": "error",
     "import/no-dynamic-require": "error",
     "import/no-internal-modules": [
       "off",
       {
-        allow: [],
-      },
+        "allow": []
+      }
     ],
     "import/unambiguous": "off",
     "import/no-webpack-loader-syntax": "error",
     "import/no-unassigned-import": "off",
     "import/no-named-default": "error",
-    "import/no-anonymous-default-export": [
-      "off",
-      {
-        allowArray: false,
-        allowArrowFunction: false,
-        allowAnonymousClass: false,
-        allowAnonymousFunction: false,
-        allowLiteral: false,
-        allowObject: false,
-      },
-    ],
+    "import/no-anonymous-default-export": ["off", {
+      allowArray: false,
+      allowArrowFunction: false,
+      allowAnonymousClass: false,
+      allowAnonymousFunction: false,
+      allowLiteral: false,
+      allowObject: false,
+    }],
     "import/exports-last": "off",
     "import/group-exports": "off",
     "import/no-default-export": "off",
@@ -998,22 +995,16 @@ module.exports = {
     "import/no-self-import": "error",
     "import/no-cycle": ["error", { maxDepth: Infinity }],
     "import/no-useless-path-segments": ["error", { commonjs: true }],
-    "import/dynamic-import-chunkname": [
-      "off",
-      {
-        importFunctions: [],
-        webpackChunknameFormat: "[0-9a-zA-Z-_/.]+",
-      },
-    ],
+    "import/dynamic-import-chunkname": ["off", {
+      importFunctions: [],
+      webpackChunknameFormat: "[0-9a-zA-Z-_/.]+",
+    }],
     "import/no-relative-parent-imports": "off",
-    "import/no-unused-modules": [
-      "off",
-      {
-        ignoreExports: [],
-        missingExports: true,
-        unusedExports: true,
-      },
-    ],
-    strict: ["error", "never"],
-  },
+    "import/no-unused-modules": ["off", {
+      ignoreExports: [],
+      missingExports: true,
+      unusedExports: true,
+    }],
+    "strict": ["error", "never"]
+  }
 };


### PR DESCRIPTION
## This Pull Request:

- Changes the values of [`prefer-destructuring`](https://eslint.org/docs/latest/rules/prefer-destructuring#options) for `AssignmentExpression` properties from `true` to `false`

## Why is this PR needed?

1. Destructuring is great for newly-declared variables, but very strange for reassignment. We don't do a lot of reassignment because we use `const` everywhere (which is good), but in the few cases where we do, the current rule encourages some uncomfortable syntax.
2. Destructuring for reassignment causes lines to start with `[`, which is [one of the only ways to introduce ASI failure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion): if the author forgets the preceding semicolon, the code will parse, but it'll do something unexpected at runtime. I don't mind writing semicolons for style reasons, but I'd prefer not to rely on them for our code to work properly.

#### Variable declarations are cool
```es6
const foo = ['hello', 'world'];
const [bar] = foo; // normal

console.log(bar); // => "hello"
```

#### Assignment expressions are weird

```es6
let bar = null;
const foo = ['hello', 'world'];

[bar] = foo; // more weird
bar = foo[0]; // less weird

console.log(bar); // => "hello"
```

#### Unexpected behavior

```es6
let bar = null;
const foo = ['hello', 'world']

[bar] = foo; // => Uncaught ReferenceError: Cannot access 'foo' before initialization
```

Without a preceding semicolon, `[bar]` becomes a property lookup rather than a destructuring assignment. If we reassign `bar` without destructuring, though, ASI will kick in and the code will work as expected (and formatting tools can fix the missing semicolon).